### PR TITLE
Add publishOrSkip method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -111,7 +111,7 @@ class Client
      * Publish message, or update if there is already a message for the same entity_id in queue
      *  Note 1: doesn't ensure there will never be duplicate messages (only to be used for performance when worker can be slow)
      *  Note 2: priority of the message will be the highest between existing and new message
-     *  Note 3: message content is overwritten (should not be used when contents may be different)
+     *  Note 3: message content is overwritten if no merge callback is passed (should not be used when contents may be different)
      *
      * @param Message\MessageInterface $message
      * @param callable|null $mergeCallback
@@ -122,6 +122,21 @@ class Client
     public function publishOrUpdateEntityMessage(Message\MessageInterface $message, ?callable $mergeCallback = null)
     {
         $this->messageRepository->publishOrUpdateEntityMessage($message, $mergeCallback);
+
+        return $this;
+    }
+
+    /**
+     * Publish message, or skip if there is already a message for the same entity_id in queue or pending
+     *
+     * @param Message\MessageInterface $message
+     * @return $this
+     * @throws Exception\EmptySetValuesException
+     * @throws Exception\PhpMqdbConfigurationException
+     */
+    public function publishOrSkipEntityMessage(Message\MessageInterface $message)
+    {
+        $this->messageRepository->publishOrSkipEntityMessage($message);
 
         return $this;
     }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -220,6 +220,22 @@ class QueryBuilder
         return $this;
     }
 
+    public function buildQueryCountExisting(Filter $filter): self
+    {
+        $this->query =
+            'SELECT COUNT(' . $this->tableConfig->getField('id') . ')' .
+            ' FROM ' . $this->tableConfig->getTable() .
+            ' WHERE ' . $this->tableConfig->getField('status') . ' IN (:status_in_queue, :status_ackp)' .
+            ' AND ' . $this->tableConfig->getField('entity_id') . ' = ' . $filter->getEntityId() .
+            ' AND ' . $this->tableConfig->getField('topic') . ' = ' . $filter->getTopic();
+        $this->bind = [
+            ':status_in_queue' => Enumerator\Status::IN_QUEUE,
+            ':status_ackp' => Enumerator\Status::ACK_PENDING,
+        ];
+
+        return $this;
+    }
+
     /**
      * Build query to update message(s) before to get it.
      *

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -226,11 +226,13 @@ class QueryBuilder
             'SELECT COUNT(' . $this->tableConfig->getField('id') . ')' .
             ' FROM ' . $this->tableConfig->getTable() .
             ' WHERE ' . $this->tableConfig->getField('status') . ' IN (:status_in_queue, :status_ackp)' .
-            ' AND ' . $this->tableConfig->getField('entity_id') . ' = ' . $filter->getEntityId() .
-            ' AND ' . $this->tableConfig->getField('topic') . ' = ' . $filter->getTopic();
+            ' AND ' . $this->tableConfig->getField('entity_id') . ' = :entity_id' .
+            ' AND ' . $this->tableConfig->getField('topic') . ' = :topic';
         $this->bind = [
             ':status_in_queue' => Enumerator\Status::IN_QUEUE,
             ':status_ackp' => Enumerator\Status::ACK_PENDING,
+            ':entity_id' => $filter->getEntityId(),
+            ':topic' => $filter->getTopic(),
         ];
 
         return $this;

--- a/src/Repository/MessageRepositoryInterface.php
+++ b/src/Repository/MessageRepositoryInterface.php
@@ -103,6 +103,17 @@ interface MessageRepositoryInterface
     public function publishOrUpdateEntityMessage(MessageInterface $message, ?callable $mergeCallback = null): MessageRepositoryInterface;
 
     /**
+     * Publish message, or skip if there is already a message for the same entity_id in queue or pending
+     *
+     * @param MessageInterface $message
+     * @return MessageRepositoryInterface
+     * @throws EmptySetValuesException
+     * @throws PhpMqdbConfigurationException
+     * @throws \Exception
+     */
+    public function publishOrSkipEntityMessage(MessageInterface $message): MessageRepositoryInterface;
+
+    /**
      * Clean pending messages with date update above given interval.
      *
      * @param  \DateInterval $interval


### PR DESCRIPTION
## Added
* `publishOrSkipEntityMessage` in Client and Repository

This method will give the possibility to publish a message only when another message with the same topic and entity id is not already in queue or pending, unlike the `publishOrUpdateEntityMessage` which only update messages in queue.