### PR TITLE
Catch DeadlockException for retry

### DIFF
--- a/src/Repository/DBALMessageRepository.php
+++ b/src/Repository/DBALMessageRepository.php
@@ -57,8 +57,8 @@ class DBALMessageRepository extends AbstractDatabaseMessageRepository
                 throw $exception;
             }
 
-            // Sleep 1/10 second
-            usleep(100000);
+            // Sleep between 25 & 100ms before retrying to prevent connections to retry at same time
+            usleep(mt_rand(25000, 100000));
 
             $this->connection->close();
             $stmt = $this->connection->prepare($query);

--- a/src/Repository/DBALMessageRepository.php
+++ b/src/Repository/DBALMessageRepository.php
@@ -51,7 +51,8 @@ class DBALMessageRepository extends AbstractDatabaseMessageRepository
             @$stmt->execute($bind);
         } catch (DriverException | DeadlockException $exception) {
 
-            // Only keep SQLState HY000 with ErrorCode 2006 (MySQL server has gone away)
+            // Keep SQLState HY000 with ErrorCode 2006 (MySQL server has gone away)
+            // And SQLState 40001 (Serialization failure: Deadlock found when trying to get lock)
             if ($exception->getErrorCode() !== 2006 || !in_array($exception->getSQLState(), ['HY000', '40001'])) {
                 throw $exception;
             }


### PR DESCRIPTION
We have many deadlock during messages that fetch that causes the whole batch to fail and stay in PENDING state waiting 4H for a retry

Catch the specific DBAL exception and retry after 1/10 sec 